### PR TITLE
Make foreground notification status configurable

### DIFF
--- a/app/src/main/java/com/etrisad/zenith/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/etrisad/zenith/data/preferences/UserPreferencesRepository.kt
@@ -43,6 +43,10 @@ enum class GSFlexPreset {
     ZENITH, NEO, COMPACT, AIRY, CUSTOM
 }
 
+enum class ForegroundNotificationStatusMode {
+    DAILY_USAGE, ACTIVE_FOCUS, DEFAULT
+}
+
 class UserPreferencesRepository(private val context: Context) {
 
     private object PreferencesKeys {
@@ -69,6 +73,7 @@ class UserPreferencesRepository(private val context: Context) {
         val FLOATING_TAB_BAR_ENABLED = booleanPreferencesKey("floating_tab_bar_enabled")
         val EXPRESSIVE_COLORS = booleanPreferencesKey("expressive_colors")
         val TOTAL_USAGE_PILL_ENABLED = booleanPreferencesKey("total_usage_pill_enabled")
+        val FOREGROUND_NOTIFICATION_STATUS_MODE = stringPreferencesKey("foreground_notification_status_mode")
         val LAST_KNOWN_DAILY_USAGE = longPreferencesKey("last_known_daily_usage")
         val LAST_KNOWN_DAILY_USAGE_DATE = stringPreferencesKey("last_known_daily_usage_date")
 
@@ -163,6 +168,9 @@ class UserPreferencesRepository(private val context: Context) {
                 floatingTabBarEnabled = preferences[PreferencesKeys.FLOATING_TAB_BAR_ENABLED] ?: false,
                 expressiveColors = preferences[PreferencesKeys.EXPRESSIVE_COLORS] ?: false,
                 totalUsagePillEnabled = preferences[PreferencesKeys.TOTAL_USAGE_PILL_ENABLED] ?: false,
+                foregroundNotificationStatusMode = preferences[PreferencesKeys.FOREGROUND_NOTIFICATION_STATUS_MODE]
+                    ?.let { runCatching { ForegroundNotificationStatusMode.valueOf(it) }.getOrNull() }
+                    ?: ForegroundNotificationStatusMode.DAILY_USAGE,
                 lastKnownDailyUsage = preferences[PreferencesKeys.LAST_KNOWN_DAILY_USAGE] ?: 0L,
                 lastKnownDailyUsageDate = preferences[PreferencesKeys.LAST_KNOWN_DAILY_USAGE_DATE] ?: "",
                 bedtimeEnabled = preferences[PreferencesKeys.BEDTIME_ENABLED] ?: false,
@@ -677,6 +685,10 @@ class UserPreferencesRepository(private val context: Context) {
         context.dataStore.edit { preferences -> preferences[PreferencesKeys.TOTAL_USAGE_PILL_ENABLED] = enabled }
     }
 
+    suspend fun setForegroundNotificationStatusMode(mode: ForegroundNotificationStatusMode) {
+        context.dataStore.edit { preferences -> preferences[PreferencesKeys.FOREGROUND_NOTIFICATION_STATUS_MODE] = mode.name }
+    }
+
     suspend fun setLastKnownDailyUsage(usage: Long, date: String) {
         context.dataStore.edit { preferences -> preferences[PreferencesKeys.LAST_KNOWN_DAILY_USAGE] = usage; preferences[PreferencesKeys.LAST_KNOWN_DAILY_USAGE_DATE] = date }
     }
@@ -1014,6 +1026,7 @@ data class UserPreferences(
     val floatingTabBarEnabled: Boolean = false,
     val expressiveColors: Boolean = false,
     val totalUsagePillEnabled: Boolean = false,
+    val foregroundNotificationStatusMode: ForegroundNotificationStatusMode = ForegroundNotificationStatusMode.DAILY_USAGE,
     val lastKnownDailyUsage: Long = 0L,
     val lastKnownDailyUsageDate: String = "",
     val bedtimeEnabled: Boolean = false,

--- a/app/src/main/java/com/etrisad/zenith/data/preferences/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/etrisad/zenith/data/preferences/UserPreferencesRepository.kt
@@ -170,7 +170,7 @@ class UserPreferencesRepository(private val context: Context) {
                 totalUsagePillEnabled = preferences[PreferencesKeys.TOTAL_USAGE_PILL_ENABLED] ?: false,
                 foregroundNotificationStatusMode = preferences[PreferencesKeys.FOREGROUND_NOTIFICATION_STATUS_MODE]
                     ?.let { runCatching { ForegroundNotificationStatusMode.valueOf(it) }.getOrNull() }
-                    ?: ForegroundNotificationStatusMode.DAILY_USAGE,
+                    ?: ForegroundNotificationStatusMode.DEFAULT,
                 lastKnownDailyUsage = preferences[PreferencesKeys.LAST_KNOWN_DAILY_USAGE] ?: 0L,
                 lastKnownDailyUsageDate = preferences[PreferencesKeys.LAST_KNOWN_DAILY_USAGE_DATE] ?: "",
                 bedtimeEnabled = preferences[PreferencesKeys.BEDTIME_ENABLED] ?: false,
@@ -1026,7 +1026,7 @@ data class UserPreferences(
     val floatingTabBarEnabled: Boolean = false,
     val expressiveColors: Boolean = false,
     val totalUsagePillEnabled: Boolean = false,
-    val foregroundNotificationStatusMode: ForegroundNotificationStatusMode = ForegroundNotificationStatusMode.DAILY_USAGE,
+    val foregroundNotificationStatusMode: ForegroundNotificationStatusMode = ForegroundNotificationStatusMode.DEFAULT,
     val lastKnownDailyUsage: Long = 0L,
     val lastKnownDailyUsageDate: String = "",
     val bedtimeEnabled: Boolean = false,

--- a/app/src/main/java/com/etrisad/zenith/service/AppUsageMonitorService.kt
+++ b/app/src/main/java/com/etrisad/zenith/service/AppUsageMonitorService.kt
@@ -20,6 +20,7 @@ import com.etrisad.zenith.data.local.entity.FocusType
 import com.etrisad.zenith.data.local.entity.ScheduleMode
 import com.etrisad.zenith.data.local.entity.ShieldEntity
 import com.etrisad.zenith.data.local.database.ZenithDatabase
+import com.etrisad.zenith.data.preferences.ForegroundNotificationStatusMode
 import com.etrisad.zenith.data.preferences.UserPreferences
 import com.etrisad.zenith.data.preferences.UserPreferencesRepository
 import com.etrisad.zenith.data.repository.ShieldRepository
@@ -113,6 +114,8 @@ class AppUsageMonitorService : Service() {
 
     private var lastMonitoringError: String? = null
     private var lastMonitoringErrorTime = 0L
+    private var foregroundNotificationStarted = false
+    private var lastNotificationRefreshTime = 0L
 
     private var monitoringWakeLock: android.os.PowerManager.WakeLock? = null
     private var monitoringLoopActive = false
@@ -303,6 +306,7 @@ class AppUsageMonitorService : Service() {
                     it.type == FocusType.GOAL && it.goalReminderPeriodMinutes > 0
                 }
                 updateRestrictedPackages()
+                refreshForegroundNotification(force = true)
             }
         }
 
@@ -322,6 +326,7 @@ class AppUsageMonitorService : Service() {
                     )
                 }
                 updateRestrictedPackages()
+                refreshForegroundNotification(force = true)
             }
         }
 
@@ -337,10 +342,12 @@ class AppUsageMonitorService : Service() {
                 cachedBedtimeEndMinutes = (endParts.getOrNull(0)?.toIntOrNull() ?: 7) * 60 + (endParts.getOrNull(1)?.toIntOrNull() ?: 0)
 
                 updateBedtimeStatus(preferences)
+                refreshForegroundNotification(force = true)
             }
         }
 
         startForeground(NOTIFICATION_ID, createNotification())
+        foregroundNotificationStarted = true
         createGoalNotificationChannel()
         createBedtimeNotificationChannel()
 
@@ -934,6 +941,17 @@ class AppUsageMonitorService : Service() {
         }
 
         updateShieldInDatabase(shield)
+        refreshForegroundNotification()
+    }
+
+    private fun refreshForegroundNotification(force: Boolean = false) {
+        if (!foregroundNotificationStarted) return
+
+        val currentTime = System.currentTimeMillis()
+        if (!force && currentTime - lastNotificationRefreshTime < NOTIFICATION_UPDATE_INTERVAL) return
+
+        lastNotificationRefreshTime = currentTime
+        notificationManager.notify(NOTIFICATION_ID, createNotification())
     }
 
     private fun updateShieldInDatabase(shield: ShieldEntity, force: Boolean = false) {
@@ -1867,12 +1885,35 @@ class AppUsageMonitorService : Service() {
 
         return NotificationCompat.Builder(this, channelId)
             .setContentTitle("Zenith is active")
-            .setContentText("Protecting your focus...")
+            .setContentText(createNotificationStatusText())
             .setSmallIcon(android.R.drawable.ic_lock_idle_lock)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
             .setOngoing(true)
             .build()
+    }
+
+    private fun createNotificationStatusText(): String {
+        val prefs = currentPreferences ?: UserPreferences()
+        val mode = prefs.foregroundNotificationStatusMode
+        return NotificationStatusFormatter.format(
+            mode = mode,
+            dailyUsageMillis = if (mode == ForegroundNotificationStatusMode.DAILY_USAGE) getTotalGlobalUsageToday() else 0L,
+            activeFocusSummary = if (mode == ForegroundNotificationStatusMode.ACTIVE_FOCUS) {
+                getActiveFocusSummary()
+            } else {
+                ActiveFocusSummary(goals = 0, shields = 0, schedules = 0)
+            }
+        )
+    }
+
+    private fun getActiveFocusSummary(): ActiveFocusSummary {
+        val activeShields = allShieldsCache.values.filter { !isPaused(it) }
+        return ActiveFocusSummary(
+            goals = activeShields.count { it.type == FocusType.GOAL },
+            shields = activeShields.count { it.type == FocusType.SHIELD },
+            schedules = activeSchedules.size
+        )
     }
 
     override fun onBind(intent: Intent?): IBinder? = null
@@ -1892,6 +1933,7 @@ class AppUsageMonitorService : Service() {
 
     companion object {
         private const val NOTIFICATION_ID = 101
+        private const val NOTIFICATION_UPDATE_INTERVAL = 60000L
         private const val BEDTIME_CHANNEL_ID = "zenith_bedtime_channel"
         private const val WIND_DOWN_NOTIFICATION_ID = 2001
         private val CRITICAL_SYSTEM_PACKAGES = setOf(

--- a/app/src/main/java/com/etrisad/zenith/service/NotificationStatusFormatter.kt
+++ b/app/src/main/java/com/etrisad/zenith/service/NotificationStatusFormatter.kt
@@ -1,0 +1,56 @@
+package com.etrisad.zenith.service
+
+import com.etrisad.zenith.data.preferences.ForegroundNotificationStatusMode
+
+data class ActiveFocusSummary(
+    val goals: Int,
+    val shields: Int,
+    val schedules: Int
+)
+
+object NotificationStatusFormatter {
+    fun format(
+        mode: ForegroundNotificationStatusMode,
+        dailyUsageMillis: Long,
+        activeFocusSummary: ActiveFocusSummary
+    ): String {
+        return when (mode) {
+            ForegroundNotificationStatusMode.DAILY_USAGE ->
+                "Usage today: ${formatDuration(dailyUsageMillis)}"
+            ForegroundNotificationStatusMode.ACTIVE_FOCUS ->
+                formatActiveFocus(activeFocusSummary)
+            ForegroundNotificationStatusMode.DEFAULT ->
+                "Protecting your focus..."
+        }
+    }
+
+    fun formatDuration(millis: Long): String {
+        val totalMinutes = (millis.coerceAtLeast(0L) / 60000L).toInt()
+        val hours = totalMinutes / 60
+        val minutes = totalMinutes % 60
+
+        return when {
+            hours > 0 && minutes > 0 -> "${hours}h ${minutes}m"
+            hours > 0 -> "${hours}h"
+            else -> "${minutes}m"
+        }
+    }
+
+    private fun formatActiveFocus(summary: ActiveFocusSummary): String {
+        val parts = buildList {
+            if (summary.goals > 0) add(pluralize(summary.goals, "goal"))
+            if (summary.shields > 0) add(pluralize(summary.shields, "shield"))
+            if (summary.schedules > 0) add(pluralize(summary.schedules, "schedule"))
+        }
+
+        return if (parts.isEmpty()) {
+            "No active focus rules"
+        } else {
+            "Active focus: ${parts.joinToString(", ")}"
+        }
+    }
+
+    private fun pluralize(count: Int, label: String): String {
+        return "$count $label${if (count == 1) "" else "s"}"
+    }
+}

--- a/app/src/main/java/com/etrisad/zenith/ui/screens/settings/FeaturesSettings.kt
+++ b/app/src/main/java/com/etrisad/zenith/ui/screens/settings/FeaturesSettings.kt
@@ -52,13 +52,6 @@ fun FeaturesSettings(
         )
 
         Spacer(modifier = Modifier.height(4.dp))
-        ForegroundNotificationStatusSelector(
-            selectedMode = preferences.foregroundNotificationStatusMode,
-            onModeChange = onForegroundNotificationStatusModeChange,
-            shape = RoundedCornerShape(8.dp)
-        )
-
-        Spacer(modifier = Modifier.height(4.dp))
         SettingsToggle(
             title = "Session Usage Overlay",
             description = "Show a floating HUD with remaining time when an app is allowed",
@@ -84,6 +77,15 @@ fun FeaturesSettings(
                 )
             }
         }
+
+        Spacer(modifier = Modifier.height(16.dp))
+        PreferenceCategory(title = "Status Notifications")
+
+        ForegroundNotificationStatusSelector(
+            selectedMode = preferences.foregroundNotificationStatusMode,
+            onModeChange = onForegroundNotificationStatusModeChange,
+            shape = RoundedCornerShape(24.dp)
+        )
 
         Spacer(modifier = Modifier.height(16.dp))
         PreferenceCategory(title = "Advanced Control")

--- a/app/src/main/java/com/etrisad/zenith/ui/screens/settings/FeaturesSettings.kt
+++ b/app/src/main/java/com/etrisad/zenith/ui/screens/settings/FeaturesSettings.kt
@@ -20,13 +20,18 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import com.etrisad.zenith.data.preferences.ForegroundNotificationStatusMode
 import com.etrisad.zenith.data.preferences.UserPreferences
+import com.etrisad.zenith.ui.components.ZenithButtonSize
+import com.etrisad.zenith.ui.components.ZenithToggleButtonGroup
+import com.etrisad.zenith.ui.components.ZenithToggleOption
 import com.google.accompanist.drawablepainter.rememberDrawablePainter
 
 @Composable
 fun FeaturesSettings(
     preferences: UserPreferences,
     onTotalUsagePillEnabledChange: (Boolean) -> Unit,
+    onForegroundNotificationStatusModeChange: (ForegroundNotificationStatusMode) -> Unit,
     onSessionUsageOverlayEnabledChange: (Boolean) -> Unit,
     onSessionUsageOverlaySizeChange: (Int) -> Unit,
     onSessionUsageOverlayOpacityChange: (Int) -> Unit,
@@ -44,6 +49,13 @@ fun FeaturesSettings(
             onCheckedChange = onTotalUsagePillEnabledChange,
             icon = Icons.Outlined.Public,
             shape = RoundedCornerShape(topStart = 24.dp, topEnd = 24.dp, bottomStart = 8.dp, bottomEnd = 8.dp)
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+        ForegroundNotificationStatusSelector(
+            selectedMode = preferences.foregroundNotificationStatusMode,
+            onModeChange = onForegroundNotificationStatusModeChange,
+            shape = RoundedCornerShape(8.dp)
         )
 
         Spacer(modifier = Modifier.height(4.dp))
@@ -104,6 +116,76 @@ fun FeaturesSettings(
             icon = Icons.Outlined.MusicNote,
             shape = RoundedCornerShape(topStart = 8.dp, topEnd = 8.dp, bottomStart = 24.dp, bottomEnd = 24.dp)
         )
+    }
+}
+
+@Composable
+fun ForegroundNotificationStatusSelector(
+    selectedMode: ForegroundNotificationStatusMode,
+    onModeChange: (ForegroundNotificationStatusMode) -> Unit,
+    shape: Shape = RoundedCornerShape(8.dp)
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = shape,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .background(
+                            MaterialTheme.colorScheme.primaryContainer,
+                            CircleShape
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Outlined.NotificationsActive,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimaryContainer,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+
+                Spacer(modifier = Modifier.width(16.dp))
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = "Status Notification",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = androidx.compose.ui.text.font.FontWeight.Bold
+                    )
+                    Text(
+                        text = "Choose what Zenith shows while monitoring is active",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            val modeOptions = listOf(
+                ForegroundNotificationStatusMode.DAILY_USAGE to "Usage",
+                ForegroundNotificationStatusMode.ACTIVE_FOCUS to "Focus",
+                ForegroundNotificationStatusMode.DEFAULT to "Default"
+            )
+
+            ZenithToggleButtonGroup(
+                options = modeOptions.map { ZenithToggleOption(text = it.second) },
+                selectedIndices = setOf(modeOptions.indexOfFirst { it.first == selectedMode }.coerceAtLeast(0)),
+                onToggle = { index -> onModeChange(modeOptions[index].first) },
+                size = ZenithButtonSize.Medium,
+                isInsideContainer = true
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/etrisad/zenith/ui/screens/settings/SettingsCategoryScreen.kt
+++ b/app/src/main/java/com/etrisad/zenith/ui/screens/settings/SettingsCategoryScreen.kt
@@ -133,6 +133,7 @@ fun SettingsCategoryScreen(
                     "features" -> FeaturesSettings(
                         preferences = preferences,
                         onTotalUsagePillEnabledChange = { enabled -> coroutineScope.launch { preferencesRepository.setTotalUsagePillEnabled(enabled) } },
+                        onForegroundNotificationStatusModeChange = { mode -> coroutineScope.launch { preferencesRepository.setForegroundNotificationStatusMode(mode) } },
                         onSessionUsageOverlayEnabledChange = { enabled -> coroutineScope.launch { preferencesRepository.setSessionUsageOverlayEnabled(enabled) } },
                         onSessionUsageOverlaySizeChange = { size -> coroutineScope.launch { preferencesRepository.setSessionUsageOverlaySize(size) } },
                         onSessionUsageOverlayOpacityChange = { opacity -> coroutineScope.launch { preferencesRepository.setSessionUsageOverlayOpacity(opacity) } },

--- a/app/src/test/java/com/etrisad/zenith/data/preferences/UserPreferencesDefaultsTest.kt
+++ b/app/src/test/java/com/etrisad/zenith/data/preferences/UserPreferencesDefaultsTest.kt
@@ -1,0 +1,14 @@
+package com.etrisad.zenith.data.preferences
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class UserPreferencesDefaultsTest {
+    @Test
+    fun defaultForegroundNotificationStatusModeKeepsNotificationSimple() {
+        assertEquals(
+            ForegroundNotificationStatusMode.DEFAULT,
+            UserPreferences().foregroundNotificationStatusMode
+        )
+    }
+}

--- a/app/src/test/java/com/etrisad/zenith/service/NotificationStatusFormatterTest.kt
+++ b/app/src/test/java/com/etrisad/zenith/service/NotificationStatusFormatterTest.kt
@@ -1,0 +1,40 @@
+package com.etrisad.zenith.service
+
+import com.etrisad.zenith.data.preferences.ForegroundNotificationStatusMode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NotificationStatusFormatterTest {
+    @Test
+    fun dailyUsageModeFormatsUsageTime() {
+        val text = NotificationStatusFormatter.format(
+            mode = ForegroundNotificationStatusMode.DAILY_USAGE,
+            dailyUsageMillis = 2 * 60 * 60 * 1000L + 15 * 60 * 1000L,
+            activeFocusSummary = ActiveFocusSummary(goals = 0, shields = 0, schedules = 0)
+        )
+
+        assertEquals("Usage today: 2h 15m", text)
+    }
+
+    @Test
+    fun activeFocusModeFormatsConfiguredFocusCounts() {
+        val text = NotificationStatusFormatter.format(
+            mode = ForegroundNotificationStatusMode.ACTIVE_FOCUS,
+            dailyUsageMillis = 0L,
+            activeFocusSummary = ActiveFocusSummary(goals = 1, shields = 2, schedules = 1)
+        )
+
+        assertEquals("Active focus: 1 goal, 2 shields, 1 schedule", text)
+    }
+
+    @Test
+    fun defaultModeKeepsExistingNotificationText() {
+        val text = NotificationStatusFormatter.format(
+            mode = ForegroundNotificationStatusMode.DEFAULT,
+            dailyUsageMillis = 0L,
+            activeFocusSummary = ActiveFocusSummary(goals = 0, shields = 0, schedules = 0)
+        )
+
+        assertEquals("Protecting your focus...", text)
+    }
+}


### PR DESCRIPTION
## Summary
- add a configurable foreground notification status mode: daily usage, active focus counts, or the existing default text
- add a Features settings control for choosing the status notification mode
- refresh the foreground service notification when preferences or focus rules change, with throttled usage updates
- add unit coverage for the notification status formatter

## Verification
- `ANDROID_HOME=C:\Users\zahed\AppData\Local\Android\Sdk ./gradlew :app:testFullDebugUnitTest --no-daemon`
- `ANDROID_HOME=C:\Users\zahed\AppData\Local\Android\Sdk ./gradlew :app:assembleFullDebug --no-daemon`
- Installed and launched a side-by-side debug APK on a connected Samsung SM-S928B as `com.etrisad.zenith.debug` to avoid wiping the existing release-signed app data.